### PR TITLE
Add related posts to posts layout below post content.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .sass-cache
 _site
 Gemfile.lock
+*.swp
+*.swo

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -3,3 +3,12 @@ layout: default
 ---
 
 {{ content }}
+
+{% if site.include_related_posts %}
+<h3>Related Posts</h3>
+<ul>
+  {% for post in site.related_posts limit:5 %}
+    <li><a href="{{ post.url }}">{{ post.title }}</a></li>
+  {% endfor %}
+</ul>
+{% endif %}

--- a/example/Gemfile
+++ b/example/Gemfile
@@ -10,7 +10,6 @@ source "https://rubygems.org"
 # Happy Jekylling!
 gem "jekyll", "3.3.1"
 
-# This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "jekyll-skeleton", path: "../"
 
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
@@ -21,3 +20,6 @@ gem "jekyll-skeleton", path: "../"
 group :jekyll_plugins do
    gem "jekyll-feed", "~> 0.6"
 end
+
+# Add classifier reborn for Latent Symantic Indexing of posts
+gem "classifier-reborn", "~> 2.1"

--- a/example/_config.yml
+++ b/example/_config.yml
@@ -23,6 +23,7 @@ baseurl: "" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: jekyllrb
 github_username:  jekyll
+include_related_posts: true
 
 # Build settings
 markdown: kramdown

--- a/example/_posts/2017-01-05-welcome-to-jekyll.markdown
+++ b/example/_posts/2017-01-05-welcome-to-jekyll.markdown
@@ -3,6 +3,8 @@ layout: post
 title:  "Welcome to Jekyll!"
 date:   2017-01-05 16:14:29 -0700
 categories: jekyll update
+tags:
+  - welcome
 ---
 You’ll find this post in your `_posts` directory. Go ahead and edit it and re-build the site to see your changes. You can rebuild the site in many different ways, but the most common way is to run `jekyll serve`, which launches a web server and auto-regenerates your site when a file is updated.
 

--- a/example/_posts/2017-01-06-getting-started.md
+++ b/example/_posts/2017-01-06-getting-started.md
@@ -1,0 +1,8 @@
+---
+layout: post
+title:  "Getting Started With Jekyll!"
+tags:
+  - welcome
+---
+
+Check out the [docs](https://jekyllrb.com/docs/) for more information about the cool things you can do with Jekyll!


### PR DESCRIPTION
It requires that the `site.include_related_posts` variable be set to
true in the `_config.yml` file. This should prevent unexpected changes
for those using the theme already and it's not something I would
consider 'minimal' behavior.

Don't forget to include the 'classifier-reborn' gem for Latent Symantic
Indexing. See the example's Gemfile (`example/Gemfile`) for an example.

Closes #3 